### PR TITLE
Fix 'Writting' typo

### DIFF
--- a/Sources/SourceDocs/Classes/MarkdownIndex.swift
+++ b/Sources/SourceDocs/Classes/MarkdownIndex.swift
@@ -72,7 +72,7 @@ class MarkdownIndex {
     }
 
     private func writeFile(file: MarkdownFile) throws {
-        fputs("  Writting documentation file: \(file.filePath)", stdout)
+        fputs("  Writing documentation file: \(file.filePath)", stdout)
         do {
             try file.write()
             fputs(" ✔\n".green, stdout)


### PR DESCRIPTION
#### Breaking
- None

#### Enhancements
- Fixes typo in printed message (`Writting documentation file:` is now `Writing documentation file:`)

#### Bug Fixes
- None