### PR TITLE
Automate setting up the xcschema to run the app with a debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+# code coverage
+default.profraw

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ docs:
 
 xcode:
 	swift package generate-xcodeproj --enable-code-coverage
+	ruby Scripts/setupRunInXcode.rb
 
 linuxmain:
 	swift test --generate-linuxmain

--- a/Scripts/setupRunInXcode.rb
+++ b/Scripts/setupRunInXcode.rb
@@ -1,0 +1,95 @@
+xcschema = <<END
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SourceDocs::SourceDocs"
+               BuildableName = "SourceDocs"
+               BlueprintName = "SourceDocs"
+               ReferencedContainer = "container:SourceDocs.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SourceDocs::SourceDocsTests"
+               BuildableName = "SourceDocsTests.xctest"
+               BlueprintName = "SourceDocsTests"
+               ReferencedContainer = "container:SourceDocs.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "YES"
+      customWorkingDirectory = "#{Dir.pwd}"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "NO">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "SourceDocs::SourceDocs"
+            BuildableName = "SourceDocs"
+            BlueprintName = "SourceDocs"
+            ReferencedContainer = "container:SourceDocs.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "generate --clean --spm-module SourceDocsDemo --output-folder docs/reference --module-name-path"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>
+END
+
+File.write("SourceDocs.xcodeproj/xcshareddata/xcschemes/SourceDocs.xcscheme", xcschema)
+puts "Set up the run command for Xcode"


### PR DESCRIPTION
#### Breaking
- None

#### Enhancements
- Makes the Xcode project support debugging out of the box after a clone using the example docs
 
<img width="1555" alt="screen shot 2018-12-16 at 1 21 33 pm" src="https://user-images.githubusercontent.com/49038/50054046-a97dd000-0135-11e9-8a28-53f3094c275c.png">

This could probably be re-written in swift if someone wants but this gets the job done with no external deps.

#### Bug Fixes
- Adds the code-coverage file to gitignore