### PR TITLE
Add/customizable file ending

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Carthage/Commandant.git",
         "state": {
           "branch": null,
-          "revision": "07cad52573bad19d95844035bf0b25acddf6b0f6",
-          "version": "0.15.0"
+          "revision": "2cd0210f897fe46c6ce42f52ccfa72b3bbb621a0",
+          "version": "0.16.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/thoughtbot/Curry.git",
         "state": {
           "branch": null,
-          "revision": "b6bf27ec9d711f607a8c7da9ca69ee9eaa201a22",
-          "version": "4.0.1"
+          "revision": "4331dd50bc1db007db664a23f32e6f3df93d4e1a",
+          "version": "4.0.2"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "cd6dfb86f496fcd96ce0bc6da962cd936bf41903",
-          "version": "7.3.1"
+          "revision": "f8657642dfdec9973efc79cc68bcef43a653a2bc",
+          "version": "8.0.2"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "5fbf13871d185526993130c3a1fad0b70bfe37ce",
-          "version": "1.3.2"
+          "revision": "94df9b449508344667e5afc7e80f8bcbff1e4c37",
+          "version": "2.1.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/onevcat/Rainbow",
         "state": {
           "branch": null,
-          "revision": "797a68d0a642609424b08f11eb56974a54d5f6e2",
-          "version": "3.1.4"
+          "revision": "9c52c1952e9b2305d4507cf473392ac2d7c9b155",
+          "version": "3.1.5"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/antitypical/Result.git",
         "state": {
           "branch": null,
-          "revision": "8fc088dcf72802801efeecba76ea8fb041fb773d",
-          "version": "4.0.0"
+          "revision": "2ca499ba456795616fbc471561ff1d963e6ae160",
+          "version": "4.1.0"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
         "state": {
           "branch": null,
-          "revision": "79ca340f609adee48defa966e6a3dd0e0acbeb08",
-          "version": "0.21.3"
+          "revision": "fd9091759201473aa234c22322a3939615aef59a",
+          "version": "0.23.2"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
         "state": {
           "branch": null,
-          "revision": "b130217d81833cecd7ddf78b76d60200f1070d98",
-          "version": "4.7.4"
+          "revision": "f43166a8e18fdd0857f29e303b1bb79a5428bca0",
+          "version": "4.9.0"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "26ab35f50ea891e8edefcc9d975db2f6b67e1d68",
-          "version": "1.0.1"
+          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
+          "version": "2.0.0"
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Typing `sourcedocs help <command>` we get a list of all options for that command
 
     [--output-folder (string)]
     	Output directory (defaults to Documentation/Reference).
+        
+    [--link-ending (string)] The string to end links with. Defaults to `".md"`.
 
     --clean|-c
     	Delete output folder before generating documentation.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ Typing `sourcedocs help <command>` we get a list of all options for that command
 
     [--output-folder (string)]
        Output directory (defaults to Documentation/Reference).
-        
+    
+    [--link-beginning (string)]
+       The string to begin links with. Defaults to an empty string.
+       
     [--link-ending (string)] 
        The string to end links with. Defaults to `".md"`.
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,15 @@ Typing `sourcedocs help <command>` we get a list of all options for that command
 
     [--module-name (string)]
     	Generate documentation for a Swift module.
+    	
+    [--input-folder (string)]
+       Input directory (defaults to the current working directory).
 
     [--output-folder (string)]
-    	Output directory (defaults to Documentation/Reference).
+       Output directory (defaults to Documentation/Reference).
         
-    [--link-ending (string)] The string to end links with. Defaults to `".md"`.
+    [--link-ending (string)] 
+       The string to end links with. Defaults to `".md"`.
 
     --clean|-c
     	Delete output folder before generating documentation.

--- a/Sources/SourceDocs/Classes/MarkdownIndex.swift
+++ b/Sources/SourceDocs/Classes/MarkdownIndex.swift
@@ -28,19 +28,19 @@ class MarkdownIndex {
     var typealiases: [MarkdownTypealias] = []
     var methods: [MarkdownMethod] = []
 
-    func write(to docsPath: String, linkEndingText: String) throws {
+    func write(to docsPath: String, linkBeginningText: String, linkEndingText: String) throws {
         extensions = flattenedExtensions()
 
         fputs("Generating Markdown documentation...\n".green, stdout)
         var content: [MarkdownConvertible] = []
 
-        try content.append(writeAndIndexFiles(items: protocols, to: docsPath, collectionTitle: "Protocols", linkEndingText: linkEndingText))
-        try content.append(writeAndIndexFiles(items: structs, to: docsPath, collectionTitle: "Structs", linkEndingText: linkEndingText))
-        try content.append(writeAndIndexFiles(items: classes, to: docsPath, collectionTitle: "Classes", linkEndingText: linkEndingText))
-        try content.append(writeAndIndexFiles(items: enums, to: docsPath, collectionTitle: "Enums", linkEndingText: linkEndingText))
-        try content.append(writeAndIndexFiles(items: extensions, to: docsPath, collectionTitle: "Extensions", linkEndingText: linkEndingText))
-        try content.append(writeAndIndexFiles(items: typealiases, to: docsPath, collectionTitle: "Typealiases", linkEndingText: linkEndingText))
-        try content.append(writeAndIndexFiles(items: methods, to: docsPath, collectionTitle: "Methods", linkEndingText: linkEndingText))
+        try content.append(writeAndIndexFiles(items: protocols, to: docsPath, collectionTitle: "Protocols", linkBeginningText: linkBeginningText, linkEndingText: linkEndingText))
+        try content.append(writeAndIndexFiles(items: structs, to: docsPath, collectionTitle: "Structs", linkBeginningText: linkBeginningText, linkEndingText: linkEndingText))
+        try content.append(writeAndIndexFiles(items: classes, to: docsPath, collectionTitle: "Classes", linkBeginningText: linkBeginningText,linkEndingText: linkEndingText))
+        try content.append(writeAndIndexFiles(items: enums, to: docsPath, collectionTitle: "Enums", linkBeginningText: linkBeginningText,linkEndingText: linkEndingText))
+        try content.append(writeAndIndexFiles(items: extensions, to: docsPath, collectionTitle: "Extensions",linkBeginningText: linkBeginningText, linkEndingText: linkEndingText))
+        try content.append(writeAndIndexFiles(items: typealiases, to: docsPath, collectionTitle: "Typealiases", linkBeginningText: linkBeginningText, linkEndingText: linkEndingText))
+        try content.append(writeAndIndexFiles(items: methods, to: docsPath, collectionTitle: "Methods", linkBeginningText: linkBeginningText, linkEndingText: linkEndingText))
 
         let footer = """
             # Reference Documentation
@@ -54,7 +54,9 @@ class MarkdownIndex {
     }
 
     private func writeAndIndexFiles(items: [MarkdownConvertible & SwiftDocDictionaryInitializable],
-                                    to docsPath: String, collectionTitle: String, linkEndingText: String) throws -> [MarkdownConvertible] {
+                                    to docsPath: String, collectionTitle: String,
+                                    linkBeginningText: String,
+                                    linkEndingText: String) throws -> [MarkdownConvertible] {
         if items.isEmpty {
             return []
         }
@@ -65,7 +67,7 @@ class MarkdownIndex {
 
         // Make links for index
         let links: [MarkdownLink] = files.map {
-            let url = "\(collectionTitle.lowercased())/\($0.filename)\(linkEndingText)"
+            let url = "\(linkBeginningText)\(collectionTitle.lowercased())/\($0.filename)\(linkEndingText)"
             return MarkdownLink(text: $0.filename, url: url)
         }
         return [

--- a/Sources/SourceDocs/Classes/MarkdownIndex.swift
+++ b/Sources/SourceDocs/Classes/MarkdownIndex.swift
@@ -28,19 +28,19 @@ class MarkdownIndex {
     var typealiases: [MarkdownTypealias] = []
     var methods: [MarkdownMethod] = []
 
-    func write(to docsPath: String) throws {
+    func write(to docsPath: String, linkEndingText: String) throws {
         extensions = flattenedExtensions()
 
         fputs("Generating Markdown documentation...\n".green, stdout)
         var content: [MarkdownConvertible] = []
 
-        try content.append(writeAndIndexFiles(items: protocols, to: docsPath, collectionTitle: "Protocols"))
-        try content.append(writeAndIndexFiles(items: structs, to: docsPath, collectionTitle: "Structs"))
-        try content.append(writeAndIndexFiles(items: classes, to: docsPath, collectionTitle: "Classes"))
-        try content.append(writeAndIndexFiles(items: enums, to: docsPath, collectionTitle: "Enums"))
-        try content.append(writeAndIndexFiles(items: extensions, to: docsPath, collectionTitle: "Extensions"))
-        try content.append(writeAndIndexFiles(items: typealiases, to: docsPath, collectionTitle: "Typealiases"))
-        try content.append(writeAndIndexFiles(items: methods, to: docsPath, collectionTitle: "Methods"))
+        try content.append(writeAndIndexFiles(items: protocols, to: docsPath, collectionTitle: "Protocols", linkEndingText: linkEndingText))
+        try content.append(writeAndIndexFiles(items: structs, to: docsPath, collectionTitle: "Structs", linkEndingText: linkEndingText))
+        try content.append(writeAndIndexFiles(items: classes, to: docsPath, collectionTitle: "Classes", linkEndingText: linkEndingText))
+        try content.append(writeAndIndexFiles(items: enums, to: docsPath, collectionTitle: "Enums", linkEndingText: linkEndingText))
+        try content.append(writeAndIndexFiles(items: extensions, to: docsPath, collectionTitle: "Extensions", linkEndingText: linkEndingText))
+        try content.append(writeAndIndexFiles(items: typealiases, to: docsPath, collectionTitle: "Typealiases", linkEndingText: linkEndingText))
+        try content.append(writeAndIndexFiles(items: methods, to: docsPath, collectionTitle: "Methods", linkEndingText: linkEndingText))
 
         let footer = """
             # Reference Documentation
@@ -54,7 +54,7 @@ class MarkdownIndex {
     }
 
     private func writeAndIndexFiles(items: [MarkdownConvertible & SwiftDocDictionaryInitializable],
-                                    to docsPath: String, collectionTitle: String) throws -> [MarkdownConvertible] {
+                                    to docsPath: String, collectionTitle: String, linkEndingText: String) throws -> [MarkdownConvertible] {
         if items.isEmpty {
             return []
         }
@@ -65,7 +65,7 @@ class MarkdownIndex {
 
         // Make links for index
         let links: [MarkdownLink] = files.map {
-            let url = "\(collectionTitle.lowercased())/\($0.filename).md"
+            let url = "\(collectionTitle.lowercased())/\($0.filename)\(linkEndingText)"
             return MarkdownLink(text: $0.filename, url: url)
         }
         return [

--- a/Sources/SourceDocs/Classes/SourceDocs.swift
+++ b/Sources/SourceDocs/Classes/SourceDocs.swift
@@ -12,6 +12,7 @@ import Rainbow
 struct SourceDocs {
     static let version = "0.5.1"
     static let defaultOutputPath = "Documentation/Reference"
+    static let defaultLinkEnding = ".md"
 
     func run() {
         let registry = CommandRegistry<SourceDocsError>()

--- a/Sources/SourceDocs/Classes/SourceDocs.swift
+++ b/Sources/SourceDocs/Classes/SourceDocs.swift
@@ -13,6 +13,7 @@ struct SourceDocs {
     static let version = "0.5.1"
     static let defaultOutputPath = "Documentation/Reference"
     static let defaultLinkEnding = ".md"
+    static let defaultLinkBeginning = ""
 
     func run() {
         let registry = CommandRegistry<SourceDocsError>()

--- a/Sources/SourceDocs/Commands/Generate.swift
+++ b/Sources/SourceDocs/Commands/Generate.swift
@@ -15,6 +15,7 @@ import SourceKittenFramework
 struct GenerateCommandOptions: OptionsProtocol {
     let spmModule: String?
     let moduleName: String?
+    let linkEndingText: String
     let outputFolder: String
     let includeModuleNameInPath: Bool
     let clean: Bool
@@ -28,6 +29,7 @@ struct GenerateCommandOptions: OptionsProtocol {
                                usage: "Generate documentation for Swift Package Manager module.")
             <*> mode <| Option(key: "module-name", defaultValue: nil,
                                usage: "Generate documentation for a Swift module.")
+            <*> mode <| Option(key: "link-ending", defaultValue: SourceDocs.defaultLinkEnding, usage: "The text to end links with. Defaults to \(SourceDocs.defaultLinkEnding).")
             <*> mode <| Option(key: "output-folder", defaultValue: SourceDocs.defaultOutputPath,
                                usage: "Output directory (defaults to \(SourceDocs.defaultOutputPath)).")
             <*> mode <| Switch(flag: "m", key: "module-name-path",
@@ -93,11 +95,12 @@ struct GenerateCommand: CommandProtocol {
 
     private func generateDocumentation(docs: [SwiftDocs], options: GenerateCommandOptions, module: String) throws {
         let docsPath = options.includeModuleNameInPath ? "\(options.outputFolder)/\(module)" : options.outputFolder
+        print("Options: \(options)")
         if options.clean {
             try CleanCommand.removeReferenceDocs(docsPath: docsPath)
         }
         process(docs: docs, options: options)
-        try MarkdownIndex.shared.write(to: docsPath)
+        try MarkdownIndex.shared.write(to: docsPath, linkEndingText: options.linkEndingText)
     }
 
     private func process(docs: [SwiftDocs], options: GenerateCommandOptions) {

--- a/Sources/SourceDocs/Commands/Generate.swift
+++ b/Sources/SourceDocs/Commands/Generate.swift
@@ -16,6 +16,7 @@ struct GenerateCommandOptions: OptionsProtocol {
     let spmModule: String?
     let moduleName: String?
     let linkEndingText: String
+    let inputFolder: String
     let outputFolder: String
     let includeModuleNameInPath: Bool
     let clean: Bool
@@ -31,6 +32,8 @@ struct GenerateCommandOptions: OptionsProtocol {
                                usage: "Generate documentation for a Swift module.")
             <*> mode <| Option(key: "link-ending", defaultValue: SourceDocs.defaultLinkEnding,
                                usage: "The text to end links with. Defaults to \(SourceDocs.defaultLinkEnding).")
+            <*> mode <| Option(key: "input-folder", defaultValue: FileManager.default.currentDirectoryPath,
+                               usage: "Path to the input directory (defaults to `FileManager.default.currentDirectoryPath`).")
             <*> mode <| Option(key: "output-folder", defaultValue: SourceDocs.defaultOutputPath,
                                usage: "Output directory (defaults to \(SourceDocs.defaultOutputPath)).")
             <*> mode <| Switch(flag: "m", key: "module-name-path",
@@ -57,10 +60,10 @@ struct GenerateCommand: CommandProtocol {
                 let docs = try parseSPMModule(moduleName: module)
                 try generateDocumentation(docs: docs, options: options, module: module)
             } else if let module = options.moduleName {
-                let docs = try parseSwiftModule(moduleName: module, args: options.xcodeArguments)
+                let docs = try parseSwiftModule(moduleName: module, args: options.xcodeArguments, path: options.inputFolder)
                 try generateDocumentation(docs: docs, options: options, module: module)
             } else {
-                let docs = try parseXcodeProject(args: options.xcodeArguments)
+                let docs = try parseXcodeProject(args: options.xcodeArguments, inputPath: options.inputFolder)
                 try generateDocumentation(docs: docs, options: options, module: "")
             }
             return Result.success(())
@@ -79,16 +82,16 @@ struct GenerateCommand: CommandProtocol {
         return docs
     }
 
-    private func parseSwiftModule(moduleName: String, args: [String]) throws -> [SwiftDocs] {
-        guard let docs = Module(xcodeBuildArguments: args, name: moduleName)?.docs else {
+    private func parseSwiftModule(moduleName: String, args: [String], path: String) throws -> [SwiftDocs] {
+        guard let docs = Module(xcodeBuildArguments: args, name: moduleName, inPath: path)?.docs else {
             let message = "Error: Failed to generate documentation for module '\(moduleName)'."
             throw SourceDocsError.internalError(message: message)
         }
         return docs
     }
 
-    private func parseXcodeProject(args: [String]) throws -> [SwiftDocs] {
-        guard let docs = Module(xcodeBuildArguments: args, name: nil)?.docs else {
+    private func parseXcodeProject(args: [String], inputPath: String) throws -> [SwiftDocs] {
+        guard let docs = Module(xcodeBuildArguments: args, name: nil, inPath: inputPath)?.docs else {
             throw SourceDocsError.internalError(message: "Error: Failed to generate documentation.")
         }
         return docs

--- a/Sources/SourceDocs/Commands/Generate.swift
+++ b/Sources/SourceDocs/Commands/Generate.swift
@@ -15,6 +15,7 @@ import SourceKittenFramework
 struct GenerateCommandOptions: OptionsProtocol {
     let spmModule: String?
     let moduleName: String?
+    let linkBeginningText: String
     let linkEndingText: String
     let inputFolder: String
     let outputFolder: String
@@ -30,6 +31,8 @@ struct GenerateCommandOptions: OptionsProtocol {
                                usage: "Generate documentation for Swift Package Manager module.")
             <*> mode <| Option(key: "module-name", defaultValue: nil,
                                usage: "Generate documentation for a Swift module.")
+            <*> mode <| Option(key: "link-beginning", defaultValue: SourceDocs.defaultLinkBeginning,
+                               usage: "The text to begin links with. Defaults to an empty string.")
             <*> mode <| Option(key: "link-ending", defaultValue: SourceDocs.defaultLinkEnding,
                                usage: "The text to end links with. Defaults to \(SourceDocs.defaultLinkEnding).")
             <*> mode <| Option(key: "input-folder", defaultValue: FileManager.default.currentDirectoryPath,
@@ -103,7 +106,7 @@ struct GenerateCommand: CommandProtocol {
             try CleanCommand.removeReferenceDocs(docsPath: docsPath)
         }
         process(docs: docs, options: options)
-        try MarkdownIndex.shared.write(to: docsPath, linkEndingText: options.linkEndingText)
+        try MarkdownIndex.shared.write(to: docsPath, linkBeginningText: options.linkBeginningText, linkEndingText: options.linkEndingText)
     }
 
     private func process(docs: [SwiftDocs], options: GenerateCommandOptions) {

--- a/Sources/SourceDocs/Commands/Generate.swift
+++ b/Sources/SourceDocs/Commands/Generate.swift
@@ -96,7 +96,6 @@ struct GenerateCommand: CommandProtocol {
 
     private func generateDocumentation(docs: [SwiftDocs], options: GenerateCommandOptions, module: String) throws {
         let docsPath = options.includeModuleNameInPath ? "\(options.outputFolder)/\(module)" : options.outputFolder
-        print("Options: \(options)")
         if options.clean {
             try CleanCommand.removeReferenceDocs(docsPath: docsPath)
         }

--- a/Sources/SourceDocs/Commands/Generate.swift
+++ b/Sources/SourceDocs/Commands/Generate.swift
@@ -29,7 +29,8 @@ struct GenerateCommandOptions: OptionsProtocol {
                                usage: "Generate documentation for Swift Package Manager module.")
             <*> mode <| Option(key: "module-name", defaultValue: nil,
                                usage: "Generate documentation for a Swift module.")
-            <*> mode <| Option(key: "link-ending", defaultValue: SourceDocs.defaultLinkEnding, usage: "The text to end links with. Defaults to \(SourceDocs.defaultLinkEnding).")
+            <*> mode <| Option(key: "link-ending", defaultValue: SourceDocs.defaultLinkEnding,
+                               usage: "The text to end links with. Defaults to \(SourceDocs.defaultLinkEnding).")
             <*> mode <| Option(key: "output-folder", defaultValue: SourceDocs.defaultOutputPath,
                                usage: "Output directory (defaults to \(SourceDocs.defaultOutputPath)).")
             <*> mode <| Switch(flag: "m", key: "module-name-path",


### PR DESCRIPTION
Hey, thanks so much for this project, it's super awesome. I'm using it to generate markdown-based documentation for [apollo-ios](https://github.com/apollographql/apollo-ios) since we've already got a theme that can generate HTML pages based on Markdown. The only issue is when that theme sees `.md` at the end of a link, it links directly to the markdown file rather than to the generated HTML page. 

This PR adds the ability to customize the text at the end of a link in the `README` - in our case, switching to `/` instead of `.md` leads to the desired behavior, but in other cases someone might want `.html` instead. This change retains existing behavior of using `.md` as a link ending by default. 

I also committed changes which were automatically applied to `Package.lock` when using `swift run` - let me know if you want me to revert that one, but it does not appear to have had any adverse affects. 

#### Enhancements
- Added ability to pass in a `--link-ending` parameter so that links in `README.md` index can be customized.
