### PR TITLE
Add '--all-modules' option to generate command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,8 @@ lint:
 	swiftlint lint --quiet --strict
 
 docs:
-	swift run sourcedocs generate --clean --spm-module SourceDocsDemo --output-folder docs/reference --module-name-path --min-acl private
-	swift run sourcedocs generate --clean --spm-module SourceDocsLib --output-folder docs/reference --module-name-path
-	swift run sourcedocs package -o docs/
+	swift run sourcedocs generate -ca -o docs/reference
+	swift run sourcedocs package -o docs
 
 linuxmain:
 	swift test --generate-linuxmain

--- a/Sources/SourceDocsCLI/GenerateCommand.swift
+++ b/Sources/SourceDocsCLI/GenerateCommand.swift
@@ -15,6 +15,10 @@ struct GenerateCommand: ParsableCommand {
         abstract: "Generates the Markdown documentation"
     )
 
+    @Flag(name: .shortAndLong,
+          help: "Generate documentation for all modules in a Swift package")
+    var allModules: Bool
+
     @Option(help: "Generate documentation for Swift Package Manager module")
     var spmModule: String?
 
@@ -57,7 +61,7 @@ struct GenerateCommand: ParsableCommand {
     var xcodeArguments: [String]
 
     func run() throws {
-        let options = DocumentOptions(spmModule: spmModule, moduleName: moduleName,
+        let options = DocumentOptions(allModules: allModules, spmModule: spmModule, moduleName: moduleName,
                                       linkBeginningText: linkBeginning, linkEndingText: linkEnding,
                                       inputFolder: inputFolder, outputFolder: outputFolder,
                                       minimumAccessLevel: minACL, includeModuleNameInPath: moduleNamePath,

--- a/Sources/SourceDocsLib/DocumentationGenerator/DocumentationGenerator.swift
+++ b/Sources/SourceDocsLib/DocumentationGenerator/DocumentationGenerator.swift
@@ -83,8 +83,7 @@ public final class DocumentationGenerator {
                     let docs = try parseSPMModule(moduleName: target.name, path: options.inputFolder)
                     try generateDocumentation(docs: docs, module: target.name)
                 }
-            }
-            else if let module = options.spmModule {
+            } else if let module = options.spmModule {
                 let docs = try parseSPMModule(moduleName: module, path: options.inputFolder)
                 try generateDocumentation(docs: docs, module: module)
             } else if let module = options.moduleName {

--- a/Sources/SourceDocsLib/DocumentationGenerator/DocumentationGenerator.swift
+++ b/Sources/SourceDocsLib/DocumentationGenerator/DocumentationGenerator.swift
@@ -11,6 +11,7 @@ import SourceKittenFramework
 /// Configuration for DocumentationGenerator
 ///
 /// - Parameters:
+///   - allModules: Generate documentation for all modules in a Swift package.
 ///   - spmModule: Generate documentation for Swift Package Manager module.
 ///   - moduleName: Generate documentation for a Swift module.
 ///   - linkBeginningText: The text to begin links with. Defaults to an empty string.
@@ -24,6 +25,7 @@ import SourceKittenFramework
 ///   - tableOfContents: Generate a table of contents with properties and methods for each type. Defaults to false.
 ///   - xcodeArguments: Array of `String` arguments to pass to xcodebuild. Defaults to an empty array.
 public struct DocumentOptions {
+    public let allModules: Bool
     public let spmModule: String?
     public let moduleName: String?
     public let linkBeginningText: String
@@ -31,18 +33,19 @@ public struct DocumentOptions {
     public let inputFolder: String
     public let outputFolder: String
     public let minimumAccessLevel: AccessLevel
-    public let includeModuleNameInPath: Bool
+    public var includeModuleNameInPath: Bool
     public let clean: Bool
     public let collapsibleBlocks: Bool
     public let tableOfContents: Bool
     public let xcodeArguments: [String]
 
-    public init(spmModule: String?, moduleName: String?,
+    public init(allModules: Bool, spmModule: String?, moduleName: String?,
                 linkBeginningText: String = "", linkEndingText: String = ".md",
                 inputFolder: String, outputFolder: String,
                 minimumAccessLevel: AccessLevel = .public, includeModuleNameInPath: Bool = false,
                 clean: Bool = false, collapsibleBlocks: Bool = false, tableOfContents: Bool = false,
                 xcodeArguments: [String] = []) {
+        self.allModules = allModules
         self.spmModule = spmModule
         self.moduleName = moduleName
         self.linkBeginningText = linkBeginningText
@@ -60,7 +63,7 @@ public struct DocumentOptions {
 
 public final class DocumentationGenerator {
 
-    let options: DocumentOptions
+    var options: DocumentOptions
     let markdownIndex: MarkdownIndex
 
     public init(options: DocumentOptions) {
@@ -72,7 +75,16 @@ public final class DocumentationGenerator {
         markdownIndex.reset()
 
         do {
-            if let module = options.spmModule {
+            if options.allModules {
+                options.includeModuleNameInPath = true
+                try PackageLoader.resolveDependencies(at: options.inputFolder)
+                let packageDump = try PackageLoader.loadPackageDump(from: options.inputFolder)
+                for target in packageDump.targets where target.type == .regular {
+                    let docs = try parseSPMModule(moduleName: target.name, path: options.inputFolder)
+                    try generateDocumentation(docs: docs, module: target.name)
+                }
+            }
+            else if let module = options.spmModule {
                 let docs = try parseSPMModule(moduleName: module, path: options.inputFolder)
                 try generateDocumentation(docs: docs, module: module)
             } else if let module = options.moduleName {
@@ -80,9 +92,10 @@ public final class DocumentationGenerator {
                                                 path: options.inputFolder)
                 try generateDocumentation(docs: docs, module: module)
             } else {
-                let docs = try parseXcodeProject(args: options.xcodeArguments, inputPath: options.inputFolder)
+                let docs = try parseXcodeProject(args: options.xcodeArguments, path: options.inputFolder)
                 try generateDocumentation(docs: docs, module: "")
             }
+            fputs("Done 🎉\n".green, stdout)
         } catch let error as SourceDocsError {
             throw error
         } catch let error {
@@ -91,14 +104,16 @@ public final class DocumentationGenerator {
     }
 
     private func parseSPMModule(moduleName: String, path: String) throws -> [SwiftDocs] {
+        fputs("Processing SwiftPM module \(moduleName)...\n", stdout)
         guard let docs = Module(spmName: moduleName, inPath: path)?.docs else {
-            let message = "Error: Failed to generate documentation for SPM module '\(moduleName)'."
+            let message = "Error: Failed to generate documentation for SwiftPM module '\(moduleName)'."
             throw SourceDocsError.internalError(message: message)
         }
         return docs
     }
 
     private func parseSwiftModule(moduleName: String, args: [String], path: String) throws -> [SwiftDocs] {
+        fputs("Processing Swift module \(moduleName)...\n", stdout)
         guard let docs = Module(xcodeBuildArguments: args, name: moduleName, inPath: path)?.docs else {
             let message = "Error: Failed to generate documentation for module '\(moduleName)'."
             throw SourceDocsError.internalError(message: message)
@@ -106,8 +121,9 @@ public final class DocumentationGenerator {
         return docs
     }
 
-    private func parseXcodeProject(args: [String], inputPath: String) throws -> [SwiftDocs] {
-        guard let docs = Module(xcodeBuildArguments: args, name: nil, inPath: inputPath)?.docs else {
+    private func parseXcodeProject(args: [String], path: String) throws -> [SwiftDocs] {
+        fputs("Processing Xcode project with arguments \(args)...\n", stdout)
+        guard let docs = Module(xcodeBuildArguments: args, name: nil, inPath: path)?.docs else {
             throw SourceDocsError.internalError(message: "Error: Failed to generate documentation.")
         }
         return docs
@@ -122,6 +138,7 @@ public final class DocumentationGenerator {
         try markdownIndex.write(to: docsPath,
                                 linkBeginningText: options.linkBeginningText,
                                 linkEndingText: options.linkEndingText)
+        markdownIndex.reset()
     }
 
     private func process(docs: [SwiftDocs]) {

--- a/Sources/SourceDocsLib/DocumentationGenerator/MarkdownIndex.swift
+++ b/Sources/SourceDocsLib/DocumentationGenerator/MarkdownIndex.swift
@@ -73,7 +73,6 @@ class MarkdownIndex {
         content.append(footer)
 
         try writeFile(file: MarkdownFile(filename: "README", basePath: docsPath, content: content))
-        fputs("Done 🎉\n".green, stdout)
     }
 
     func writeAndIndexFiles(items: [MarkdownConvertible & SwiftDocDictionaryInitializable],

--- a/Tests/SourceDocsLibTests/SwiftDocDictionaryTests.swift
+++ b/Tests/SourceDocsLibTests/SwiftDocDictionaryTests.swift
@@ -16,7 +16,7 @@ class SwiftDocDictionaryTests: XCTestCase {
 
     func testIsKind() {
         let dict: SwiftDocDictionary = [
-            "key.kind": "source.lang.swift.decl.function.free",
+            "key.kind": "source.lang.swift.decl.function.free"
         ]
         XCTAssertTrue(dict.isKind(.functionFree), "Expected .functionFree")
     }
@@ -28,7 +28,7 @@ class SwiftDocDictionaryTests: XCTestCase {
 
     func testIsOneOf() {
         let dict: SwiftDocDictionary = [
-            "key.kind": "source.lang.swift.decl.function.free",
+            "key.kind": "source.lang.swift.decl.function.free"
         ]
         XCTAssertTrue(dict.isKind([.functionFree, .functionMethodClass]), "Expected match")
     }

--- a/Tests/SourceDocsLibTests/SwiftDocDictionaryTests.swift
+++ b/Tests/SourceDocsLibTests/SwiftDocDictionaryTests.swift
@@ -1,0 +1,143 @@
+//
+//  SwiftDocDictionaryTests.swift
+//  
+//
+//  Created by Eneko Alonso on 5/19/20.
+//
+
+import XCTest
+import SourceKittenFramework
+@testable import SourceDocsLib
+
+class SwiftDocDictionaryTests: XCTestCase {
+
+    let defaultOptions = MarkdownOptions(collapsibleBlocks: false, tableOfContents: false,
+                                         minimumAccessLevel: .public)
+
+    func testIsKind() {
+        let dict: SwiftDocDictionary = [
+            "key.kind": "source.lang.swift.decl.function.free",
+        ]
+        XCTAssertTrue(dict.isKind(.functionFree), "Expected .functionFree")
+    }
+
+    func testIsNotKind() {
+        let dict: SwiftDocDictionary = [:]
+        XCTAssertFalse(dict.isKind(.functionFree), "Expected not to match")
+    }
+
+    func testIsOneOf() {
+        let dict: SwiftDocDictionary = [
+            "key.kind": "source.lang.swift.decl.function.free",
+        ]
+        XCTAssertTrue(dict.isKind([.functionFree, .functionMethodClass]), "Expected match")
+    }
+
+    func testIsNotOneOf() {
+        let dict: SwiftDocDictionary = [:]
+        XCTAssertFalse(dict.isKind([.functionFree, .functionMethodClass]), "Expected match")
+    }
+
+    func testNoName() {
+        let dict: SwiftDocDictionary = [
+            "key.accessibility": "source.lang.swift.accessibility.public",
+            "key.kind": "source.lang.swift.decl.function.free"
+        ]
+        guard let method = MarkdownMethod(dictionary: dict, options: defaultOptions) else {
+            XCTFail("Expected method")
+            return
+        }
+        XCTAssertEqual(method.name, "[NO NAME]", "Expected [NO NAME]")
+    }
+
+    func testComment() {
+        let dict: SwiftDocDictionary = [
+            "key.doc.comment": "Foo Bar",
+            "key.accessibility": "source.lang.swift.accessibility.public",
+            "key.kind": "source.lang.swift.decl.function.free"
+        ]
+        guard let method = MarkdownMethod(dictionary: dict, options: defaultOptions) else {
+            XCTFail("Expected method")
+            return
+        }
+        XCTAssertEqual(method.comment, "Foo Bar", "Expected comment")
+    }
+
+    func testNoComment() {
+        let dict: SwiftDocDictionary = [
+            "key.accessibility": "source.lang.swift.accessibility.public",
+            "key.kind": "source.lang.swift.decl.function.free"
+        ]
+        guard let method = MarkdownMethod(dictionary: dict, options: defaultOptions) else {
+            XCTFail("Expected method")
+            return
+        }
+        XCTAssertEqual(method.comment, "", "Expected no comment")
+    }
+
+    func testDeclaration() {
+        let dict: SwiftDocDictionary = [
+            "key.parsed_declaration": "Foo Bar",
+            "key.accessibility": "source.lang.swift.accessibility.public",
+            "key.kind": "source.lang.swift.decl.function.free"
+        ]
+        guard let method = MarkdownMethod(dictionary: dict, options: defaultOptions) else {
+            XCTFail("Expected method")
+            return
+        }
+        let expectation = """
+        ```swift
+        Foo Bar
+        ```
+        """
+        XCTAssertEqual(method.declaration, expectation, "Expected declaration")
+    }
+
+    func testNoDeclaration() {
+        let dict: SwiftDocDictionary = [
+            "key.accessibility": "source.lang.swift.accessibility.public",
+            "key.kind": "source.lang.swift.decl.function.free"
+        ]
+        guard let method = MarkdownMethod(dictionary: dict, options: defaultOptions) else {
+            XCTFail("Expected method")
+            return
+        }
+        XCTAssertEqual(method.declaration, "", "Expected no declaration")
+    }
+
+    func testCollectionOutput() {
+        let dict: SwiftDocDictionary = [
+            "key.accessibility": "source.lang.swift.accessibility.public",
+            "key.kind": "source.lang.swift.decl.function.free"
+        ]
+        guard let method = MarkdownMethod(dictionary: dict, options: defaultOptions) else {
+            XCTFail("Expected method")
+            return
+        }
+        let collection = ["Foo", "Bar", "Baz"]
+
+        let expectation = """
+        FooBar
+        Foo
+
+        Bar
+
+        Baz
+        """
+        let output = method.collectionOutput(title: "FooBar", collection: collection)
+        XCTAssertEqual(output, expectation, "Expected collection")
+    }
+
+    func testEmptyCollectionOutput() {
+        let dict: SwiftDocDictionary = [
+            "key.accessibility": "source.lang.swift.accessibility.public",
+            "key.kind": "source.lang.swift.decl.function.free"
+        ]
+        guard let method = MarkdownMethod(dictionary: dict, options: defaultOptions) else {
+            XCTFail("Expected method")
+            return
+        }
+        let output = method.collectionOutput(title: "FooBar", collection: [])
+        XCTAssertEqual(output, "", "Expected empty output")
+    }
+}

--- a/docs/reference/SourceDocsDemo/classes/ACLTestClass.md
+++ b/docs/reference/SourceDocsDemo/classes/ACLTestClass.md
@@ -31,35 +31,3 @@ public func publicMethod()
 ```
 
 > Method with `public` access level
-
-### `implicitInternalMethod()`
-
-```swift
-func implicitInternalMethod()
-```
-
-> Method with implicit `internal` access level
-
-### `explicitInternalMethod()`
-
-```swift
-internal func explicitInternalMethod()
-```
-
-> Method with explicit `internal` access level
-
-### `filePrivateMethod()`
-
-```swift
-fileprivate func filePrivateMethod()
-```
-
-> Method with explicit `fileprivate` access level
-
-### `privateMethod()`
-
-```swift
-private func privateMethod()
-```
-
-> Method with explicit `private` access level

--- a/docs/reference/SourceDocsLib/README.md
+++ b/docs/reference/SourceDocsLib/README.md
@@ -14,12 +14,14 @@
 
 -   [AccessLevel](enums/AccessLevel.md)
 -   [Error](enums/Error.md)
+-   [SourceDocsError](enums/SourceDocsError.md)
 
 ## Extensions
 
 -   [AccessLevel](extensions/AccessLevel.md)
+-   [SourceDocsError](extensions/SourceDocsError.md)
 
 This reference documentation was generated with
 [SourceDocs](https://github.com/eneko/SourceDocs).
 
-Generated at 2020-05-10 22:29:09 +0000
+Generated at 2020-05-19 05:14:03 +0000

--- a/docs/reference/SourceDocsLib/enums/SourceDocsError.md
+++ b/docs/reference/SourceDocsLib/enums/SourceDocsError.md
@@ -1,0 +1,14 @@
+**ENUM**
+
+# `SourceDocsError`
+
+```swift
+public enum SourceDocsError: Error
+```
+
+## Cases
+### `internalError(message:)`
+
+```swift
+case internalError(message: String)
+```

--- a/docs/reference/SourceDocsLib/extensions/SourceDocsError.md
+++ b/docs/reference/SourceDocsLib/extensions/SourceDocsError.md
@@ -1,0 +1,13 @@
+**EXTENSION**
+
+# `SourceDocsError`
+```swift
+extension SourceDocsError: LocalizedError
+```
+
+## Properties
+### `errorDescription`
+
+```swift
+public var errorDescription: String?
+```

--- a/docs/reference/SourceDocsLib/structs/DocumentOptions.md
+++ b/docs/reference/SourceDocsLib/structs/DocumentOptions.md
@@ -9,6 +9,7 @@ public struct DocumentOptions
 > Configuration for DocumentationGenerator
 >
 > - Parameters:
+>   - allModules: Generate documentation for all modules in a Swift package.
 >   - spmModule: Generate documentation for Swift Package Manager module.
 >   - moduleName: Generate documentation for a Swift module.
 >   - linkBeginningText: The text to begin links with. Defaults to an empty string.
@@ -23,6 +24,12 @@ public struct DocumentOptions
 >   - xcodeArguments: Array of `String` arguments to pass to xcodebuild. Defaults to an empty array.
 
 ## Properties
+### `allModules`
+
+```swift
+public let allModules: Bool
+```
+
 ### `spmModule`
 
 ```swift
@@ -68,7 +75,7 @@ public let minimumAccessLevel: AccessLevel
 ### `includeModuleNameInPath`
 
 ```swift
-public let includeModuleNameInPath: Bool
+public var includeModuleNameInPath: Bool
 ```
 
 ### `clean`
@@ -96,10 +103,10 @@ public let xcodeArguments: [String]
 ```
 
 ## Methods
-### `init(spmModule:moduleName:linkBeginningText:linkEndingText:inputFolder:outputFolder:minimumAccessLevel:includeModuleNameInPath:clean:collapsibleBlocks:tableOfContents:xcodeArguments:)`
+### `init(allModules:spmModule:moduleName:linkBeginningText:linkEndingText:inputFolder:outputFolder:minimumAccessLevel:includeModuleNameInPath:clean:collapsibleBlocks:tableOfContents:xcodeArguments:)`
 
 ```swift
-public init(spmModule: String?, moduleName: String?,
+public init(allModules: Bool, spmModule: String?, moduleName: String?,
             linkBeginningText: String = "", linkEndingText: String = ".md",
             inputFolder: String, outputFolder: String,
             minimumAccessLevel: AccessLevel = .public, includeModuleNameInPath: Bool = false,


### PR DESCRIPTION
#### Enhancements
- Add `--all-modules` option to `generate` command for generating documentation for all modules in a package.

