### PR TITLE
Fix prebuilt binary link

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ job rendering Markdown files, so your documentation will be very nice to read.
 
 ### Download Binary
 
-    $ curl -Ls https://github.com/eneko/SourceDocs/releases/download/latest/sourcedocs.macos.zip -o /tmp/sourcedocs.macos.zip
+    $ curl -Ls https://github.com/eneko/SourceDocs/releases/latest/download/sourcedocs.macos.zip -o /tmp/sourcedocs.macos.zip
     $ unzip -j -d /usr/local/bin /tmp/sourcedocs.macos.zip 
 
 ### From Sources


### PR DESCRIPTION
Would it be possible to have prebuilt binaries attached to the releases again? (1.2.0 does not have one atm) Thanks! :)