### PR TITLE
Prepare release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 - None
 
 
+## 1.2.1
+
+#### Bug Fixes
+- Fix issue with `System` library renamed to `ProcessRunner`
+
+
 ## 1.2.0
 
 #### Enhancements
@@ -26,7 +32,7 @@
 
 #### Enhancements
 - New `--all-modules` parameter to generate documentation for all swift modules in a package (#49)
-- New `--reproducible-docs` parameter to generate reproducible documentation (#51) 
+- New `--reproducible-docs` parameter to generate reproducible documentation (#51)
 
 #### Bug Fixes
 - Fix issue #50, where nested types where documented out of their parent context (#51)
@@ -60,7 +66,7 @@
 
 ## 0.6.0
 
-#### Breaking 
+#### Breaking
 - SourceDocs now requires Swift 5.0 or higher
 
 #### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ## 1.2.1
 
 #### Bug Fixes
-- Fix issue with `System` library renamed to `ProcessRunner`
+- Fix issue with `System` library renamed to `ProcessRunner` (#60)
 
 
 ## 1.2.0

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TOOL_NAME = sourcedocs
-VERSION = 1.2.0
+VERSION = 1.2.1
 
 PREFIX = /usr/local
 INSTALL_PATH = $(PREFIX)/bin/$(TOOL_NAME)
@@ -13,7 +13,7 @@ install: build
 	install -C -m 755 $(BUILD_PATH) $(INSTALL_PATH)
 
 build:
-	swift build --disable-sandbox -c release 
+	swift build --disable-sandbox -c release
 
 uninstall:
 	rm -f $(INSTALL_PATH)

--- a/Sources/SourceDocsCLI/main.swift
+++ b/Sources/SourceDocsCLI/main.swift
@@ -9,7 +9,7 @@ import Foundation
 import ArgumentParser
 
 struct SourceDocs: ParsableCommand {
-    static let version = "1.2.0"
+    static let version = "1.2.1"
     static let defaultOutputPath = "Documentation/Reference"
     static let defaultLinkEnding = ".md"
     static let defaultLinkBeginning = ""

--- a/Tests/SourceDocsCLITests/VersionCommandTests.swift
+++ b/Tests/SourceDocsCLITests/VersionCommandTests.swift
@@ -12,7 +12,7 @@ class VersionCommandTests: XCTestCase {
 
     func testVersion() throws {
         let result = try system(command: binaryURL.path, parameters: ["version"], captureOutput: true)
-        XCTAssertEqual(result.standardOutput, "SourceDocs v1.2.0")
+        XCTAssertEqual(result.standardOutput, "SourceDocs v1.2.1")
     }
 
 }


### PR DESCRIPTION
#### Bug Fixes
- Fix issue with `System` library renamed to `ProcessRunner` (#60)
