### PR TITLE
Fix issue #66 Static members were ignored by documentation generator

### DIFF
--- a/Sources/SourceDocsLib/DocumentationGenerator/Elements/MarkdownVariable.swift
+++ b/Sources/SourceDocsLib/DocumentationGenerator/Elements/MarkdownVariable.swift
@@ -18,7 +18,8 @@ struct MarkdownVariable: SwiftDocDictionaryInitializable, MarkdownConvertible {
     }
 
     init?(dictionary: SwiftDocDictionary, options: MarkdownOptions) {
-        guard dictionary.accessLevel >= options.minimumAccessLevel && dictionary.isKind(.varInstance) else {
+        let variables: [SwiftDeclarationKind] = [.varInstance, .varStatic]
+        guard dictionary.accessLevel >= options.minimumAccessLevel && dictionary.isKind(variables) else {
             return nil
         }
         self.dictionary = dictionary


### PR DESCRIPTION
#### Breaking
- None

#### Enhancements
- None

#### Bug Fixes
- All static members (`static let` and `static var` ) were ignored by the documentation generator. These members are useful inside a code documentation.
