### PR TITLE
Document how to install sourcedocs using Mise

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ Requirements:
 
     $ brew install sourcedocs
 
+#### Using [Mise](https://mise.jdx.dev/)
+
+    $ mise plugins add sourcedocs https://github.com/tuist/asdf-sourcedocs.git
+    $ mise install sourcedocs
+    $ mise use -g sourcedocs@latest
+
+
 #### Building with Swift Package Manager
 
     $ git clone https://github.com/eneko/SourceDocs.git


### PR DESCRIPTION
#### Enhancements
We implemented a [asdf plugin](https://github.com/tuist/asdf-sourcedocs.git) to install SourceDocs using [Mise](https://mise.jdx.dev/) so I'm updating the README to tell the users of the tool that there's an additional installation method. We are going to use that installation method ourselves so we can take care of its maintenance.

For context, Mise is able to deterministically install versions and activate them scoped to a particular directory (e.g. the project directory)