### PR TITLE
Supporting docs generation on Swift 5.10

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         xcode: 
-        - 13.1
+        - 15.4
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app
     steps:

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
         "state": {
           "branch": null,
-          "revision": "817dfa6f2e09b0476f3a6c9dbc035991f02f0241",
-          "version": "0.32.0"
+          "revision": "fbd6bbcddffa97dca4b8a6b5d5a8246a430be9c7",
+          "version": "0.36.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "82905286cc3f0fa8adc4674bf49437cab65a8373",
-          "version": "1.1.1"
+          "revision": "41982a3656a71c768319979febd796c6fd111d5c",
+          "version": "1.5.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
         "state": {
           "branch": null,
-          "revision": "6469881a3f30417c5bb02404ea4b69207f297592",
-          "version": "6.0.0"
+          "revision": "a853604c9e9a83ad9954c7e3d2a565273982471f",
+          "version": "7.0.2"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-          "version": "4.0.6"
+          "revision": "3036ba9d69cf1fd04d433527bc339dc0dc75433d",
+          "version": "5.1.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 import PackageDescription
 import Foundation
 
 let package = Package(
     name: "SourceDocs",
     platforms: [
-        .macOS(.v10_15)
+        .macOS(.v12)
     ],
     products: [
         .executable(name: "sourcedocs", targets: ["SourceDocsCLI"]),

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/eneko/ProcessRunner.git", from: "1.1.0")
     ],
     targets: [
-        .target(name: "SourceDocsCLI", dependencies: [
+        .executableTarget(name: "SourceDocsCLI", dependencies: [
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
             "SourceDocsLib",
             "Rainbow"

--- a/Sources/SourceDocsCLI/SourceDocsCLI.swift
+++ b/Sources/SourceDocsCLI/SourceDocsCLI.swift
@@ -8,6 +8,7 @@
 import Foundation
 import ArgumentParser
 
+@main
 struct SourceDocs: ParsableCommand {
     static let version = "2.0.1"
     static let defaultOutputPath = "Documentation/Reference"
@@ -23,5 +24,3 @@ struct SourceDocs: ParsableCommand {
         ]
     )
 }
-
-SourceDocs.main()

--- a/Sources/SourceDocsLib/PackageProcessor/PackageDump.swift
+++ b/Sources/SourceDocsLib/PackageProcessor/PackageDump.swift
@@ -95,6 +95,7 @@ struct PackageDump: Codable {
         enum TargetType: String, Codable {
             case regular
             case test
+            case executable
         }
     }
 }


### PR DESCRIPTION
#### Breaking
- Swift 5.7 or higher required for build 

#### Enhancements
- Bump dependencies
  - `SourceKitten`: 0.32.0 -> 0.36.0
  - `swift-argument-parse`: 1.1.1 -> 1.5.0
  - `SWXMLHash`: 6.0.0 -> 7.0.2
  - `Yams`: 4.0.6 -> 5.1.3
- Fix warning and unit test caused by changing swift-tools-version to 5.7
  - for details: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0294-package-executable-targets.md

#### Bug Fixes
- None
